### PR TITLE
16356_GS_Support_Auth2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bc-payments-sdk",
-  "version": "0.3.3",
+  "version": "0.3.3-canary.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bc-payments-sdk",
-      "version": "0.3.3",
+      "version": "0.3.3-canary.1",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-payments-sdk",
-  "version": "0.3.3",
+  "version": "0.3.3-canary.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/config/BCEnvironment.ts
+++ b/src/base/config/BCEnvironment.ts
@@ -34,6 +34,18 @@ export class BCEnvironment {
      *
      * @property {string}
      */
+    static apiToken: string;
+
+    /**
+     *
+     * @property {string}
+     */
+    static refreshToken: string;
+
+    /**
+     *
+     * @property {string}
+     */
     static defaultCountry: string;
 
     /**
@@ -102,11 +114,11 @@ export class BCEnvironment {
         BCEnvironment.thisObj = new BCEnvironment();
         BCEnvironment.clientId = clientId;
         BCEnvironment.sharedSecret = sharedSecret;
-        BCEnvironment.baseAuthUrl = Endpoints.Base.AUTH_URL;
-        BCEnvironment.baseApiUrl = Endpoints.Base.API_URL;
-        BCEnvironment.defaultCountry = "GB";
-        BCEnvironment.defaultCurrency = "GBP";
-        BCEnvironment.defaultLanguage = "en-GB";
+        BCEnvironment.baseAuthUrl = baseAuthUrl || Endpoints.Base.AUTH_URL;
+        BCEnvironment.baseApiUrl = baseApiUrl || Endpoints.Base.API_URL;
+        BCEnvironment.defaultCountry = defaultCountry || "GB";
+        BCEnvironment.defaultCurrency = defaultCurrency || "GBP";
+        BCEnvironment.defaultLanguage = defaultLanguage || "en-GB";
         BCEnvironment.config = config;
         BCEnvironment.enableProviderLogging = true;
 
@@ -139,6 +151,63 @@ export class BCEnvironment {
         }
         return BCEnvironment.thisObj;
         //}
+    }
+
+    /**
+     * Initializes the BCEnvironment object with the required parameters to make API calls.
+     * This method should be used when you already have a valid API token and refresh token.
+     * @param {string} apiToken - The API token to use for authentication.
+     * @param {string} refreshToken - The refresh token to use when the API token expires.
+     * @param {Object} [config] - The configuration for payment gateways etc.
+     * @param {string} [baseAuthUrl] - The base URL for the authentication API.
+     * @param {string} [baseApiUrl] - The base URL for the API.
+     * @param {number} [connectTimeout] - The timeout for the connection in milliseconds.
+     * @param {number} [readTimeout] - The timeout for reading the response in milliseconds.
+     * @param {string} [defaultCountry] - The default country to use for the API.
+     * @param {string} [defaultCurrency] - The default currency to use for the API.
+     * @param {string} [defaultLanguage] - The default language to use for the API.
+     * @returns {BCEnvironment} - The initialized BCEnvironment object.
+     */
+    static initSession(apiToken: string, refreshToken: string, config?: any, baseAuthUrl?: string, baseApiUrl?: string, connectTimeout?: number, readTimeout?: number, defaultCountry?: string, defaultCurrency?: string, defaultLanguage?: string) {
+        BCEnvironment.thisObj = new BCEnvironment();
+        BCEnvironment.apiToken = apiToken;
+        BCEnvironment.refreshToken = refreshToken;
+        BCEnvironment.baseAuthUrl = baseAuthUrl || Endpoints.Base.AUTH_URL;
+        BCEnvironment.baseApiUrl = baseApiUrl || Endpoints.Base.API_URL;
+        BCEnvironment.defaultCountry = defaultCountry || "GB";
+        BCEnvironment.defaultCurrency = defaultCurrency || "GBP";
+        BCEnvironment.defaultLanguage = defaultLanguage || "en-GB";
+        BCEnvironment.config = config;
+        BCEnvironment.enableProviderLogging = true;
+
+        if (baseAuthUrl) {
+            BCEnvironment.baseAuthUrl = baseAuthUrl;
+        }
+
+        if (baseApiUrl) {
+            BCEnvironment.baseApiUrl = baseApiUrl;
+        }
+
+        if (connectTimeout) {
+            BCEnvironment.connectTimeout = connectTimeout;
+        }
+
+        if (readTimeout) {
+            BCEnvironment.readTimeout = readTimeout;
+        }
+
+        if (defaultCountry) {
+            BCEnvironment.defaultCountry = defaultCountry;
+        }
+
+        if (defaultCurrency) {
+            BCEnvironment.defaultCurrency = defaultCurrency;
+        }
+
+        if (defaultLanguage) {
+            BCEnvironment.defaultLanguage = defaultLanguage;
+        }
+        return BCEnvironment.thisObj;
     }
 
     /**
@@ -225,6 +294,25 @@ export class BCEnvironment {
     }
 
     /**
+     * Retrieves the API token used for authentication.
+     * 
+     * @return {string} The API token.
+     */
+    static getApiToken(): string {
+        return BCEnvironment.apiToken;
+    }
+
+    /**
+     * Retrieves the refresh token used for authentication.
+     * 
+     * @return {string} The refresh token.
+     */
+
+    static getRefreshToken(): string {
+        return BCEnvironment.refreshToken;
+    }
+
+    /**
      * Retrieves the default country associated with the BetterCommerce account.
      * 
      * @return {string} The default country.
@@ -294,5 +382,23 @@ export class BCEnvironment {
      */
     static getEnableProviderLogging(): boolean {
         return BCEnvironment.enableProviderLogging;
+    }
+
+    /**
+     * Sets the API token for the BetterCommerce API.
+     * 
+     * @param {string} apiToken - The API token to set.
+     */
+    static setApiToken(apiToken: string): void {
+        BCEnvironment.apiToken = apiToken;
+    }
+
+    /**
+     * Sets the refresh token for the BetterCommerce API.
+     * 
+     * @param {string} refreshToken - The refresh token to set.
+     */
+    static setRefreshToken(refreshToken: string): void {
+        BCEnvironment.refreshToken = refreshToken;
     }
 }

--- a/tests/better-commerce/get-payment-methods-apitoken.test.js
+++ b/tests/better-commerce/get-payment-methods-apitoken.test.js
@@ -1,8 +1,9 @@
 const { BCEnvironment } = require("../../dist");
 const { PaymentMethod } = require("../../dist/modules/better-commerce/PaymentMethod");
 
-//BCEnvironment.init("505c82a3-3493-493b-b359-a881b8414bf5", "wHfsCPUlgUX/I8d0xJbAaz9Fy67BN2Vh8k6T4AFqrUw=");
-BCEnvironment.init("f6f142a0-caec-4379-9f49-031dcb133360", "lUpL2QJ9yO/PvoUhOUWDkannmXorikEyCrMmS0AlWbg=", null, "https://auth.dev-omnicx.com", "https://api20.dev-omnicx.com"); //DEV
+const apiToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJhcHAuYmV0dGVyY29tbWVyY2UuaW8iLCJpc3MiOiJhdXRoLmJldHRlcmNvbW1lcmNlLmlvIiwiZXhwIjoxNzQ5OTA4MTU0LCJzdWIiOiI5QzYuY29tIiwiVXNlcklkIjoiOUMwRUIwRTctNjg5Mi00N0M0LUFEREItRThFNTU3MjZFQURCIiwiaHR0cDovL3NjaGVtYXMubWljcm9zb2Z0LmNvbS93cy8yMDA4LzA2L2lkZW50aXR5L2NsYWltcy9yb2xlIjpbIlNhbGVzIE1hbmFnZXI0OnVzZXI6Y3JlYXRlIiwidHJhZGVpbjpxdW90ZWxpbmU6YWRkIiwidHJhZGVpbjpxdW90ZTpjcmVhdGUiLCJhY2NvdW50OnVzZXI";
+const refreshToken = "aFT+RsaABvRAY1DjWkVn6P9o+fG0FJBnZW7OZB5nMkM="
+BCEnvironment.initSession(apiToken, refreshToken, null, "https://auth2.dev-omnicx.com", "https://api20.dev-omnicx.com")
 const params = {
     countryCode: "GB",
     currencyCode: "GBP",
@@ -11,21 +12,16 @@ const params = {
 
 const headers = {
     Currency: 'GBP',
-    Language: 'en',
+    Language: 'en-GB',
     Country: 'GB',
-    DeviceId: 'db462e8b-d7a6-4f6d-91e2-b4a86b8e0fa9',
-    SessionId: '0660a258-c504-483a-886d-83d360a474c6'
 },
     cookies = {
-        basketId: 'd7b434f0-8812-4bda-b1c7-b60953058714',
-        deviceId: 'db462e8b-d7a6-4f6d-91e2-b4a86b8e0fa9',
         Currency: 'GBP',
         Language: 'en',
         Country: 'GB',
         accept_cookies: 'accepted',
         __stripe_mid: '60540aa8-92ec-448c-9c50-92ac4170268e19af4b',
         defaultSession: '167602a5-4cef-4e81-b8f7-bb16af38d46d',
-        sessionId: '0660a258-c504-483a-886d-83d360a474c6'
     };
 
 PaymentMethod.getAll(params, { headers, cookies })


### PR DESCRIPTION
- Introduces `apiToken` and `refreshToken` properties to `BCEnvironment` for API authentication.
- Adds `initSession` method to `BCEnvironment` for initializing the environment with API and refresh tokens.
- Implements token refresh logic in `fetcher.ts` using the refresh token when the API token expires.
- Updates `getToken` function in `fetcher.ts` to use `BCEnvironment.getApiToken()` if available.
- Updates tests to use `initSession` with API and refresh tokens.
- Updates package version to 0.3.3-canary.1.