### PR TITLE
fix/FB1453_return_orderId_in_loyalty_response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-payments-sdk",
-  "version": "0.3.7-rc.5",
+  "version": "0.3.7-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-payments-sdk",
-  "version": "0.3.7-rc.5",
+  "version": "0.3.7-rc.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operations/BetterCommerceOperation.ts
+++ b/src/operations/BetterCommerceOperation.ts
@@ -484,7 +484,11 @@ export class BetterCommerceOperation implements ICommerceProvider {
                     const totalPartiallyPaidAmountWithoutLoyalty = totalPartiallyPaidAmount;
                     loyaltyPointsPaymentResponse = await this.handleLoyaltyPointsPayment(isPartialPayment, orderAmount, data?.extras, totalPartiallyPaidAmountWithoutLoyalty, true)
                     const isLoyaltyPointsPayment = (loyaltyPointsPaymentResponse?.id && loyaltyPointsPaymentResponse?.id !== Guid.empty)
-                    return isLoyaltyPointsPayment ? PaymentStatus.PAID : PaymentStatus.PENDING;
+                    // Return an object with status and orderId so the frontend can redirect correctly
+                    return {
+                        status: isLoyaltyPointsPayment ? PaymentStatus.PAID : PaymentStatus.PENDING,
+                        orderId: loyaltyPointsPaymentResponse?.orderId || null,
+                    };
                 }
             }
         } catch (error: any) {
@@ -1353,7 +1357,8 @@ export class BetterCommerceOperation implements ICommerceProvider {
                         await Logger.logPayment({ data: orderModel, message: `${paymentMethod?.methodName?.toLowerCase()} | UpdatePaymentResponse API20 Request` }, { headers: {}, cookies: {} })
                         console.log('--- Loyalty paymentResponseInput ---', JSON.stringify(paymentResponseInput))
                         const { result: paymentResponseResult } = await Checkout.updatePaymentResponse(paymentResponseInput, { cookies: {} });
-                        return paymentResponseResult
+                        // Return both paymentResponseResult and orderId so the frontend can redirect correctly
+                        return { ...paymentResponseResult, orderId }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Return orderId along with payment status in loyalty payment response
- Ensures frontend can correctly redirect after loyalty points payment

## Test plan
- [x] Verify loyalty points full payment returns orderId for redirect
- [x] Verify partial payment with loyalty points returns orderId correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)